### PR TITLE
Relative path now replaces all occurances of \

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function(fileName, opts) {
 
         if (!firstFile) firstFile = file;
 
-        var rel = path.relative(file.cwd, file.path).replace('\\', '/');
+        var rel = path.relative(file.cwd, file.path).replace(/\\/g, '/');
 
         if(opts.prefix) {
             var p = opts.prefix;


### PR DESCRIPTION
When using the option prefix larger than 1 it failed. 
This was because the replace only replaced the first match of \ in the relative path. 
Replaced it with a regex matches all occurrences of \ and allows for prefix subtraction bigger than 1.
