### PR TITLE
Pin source-map version to 0.1.33 to avoid bug introduced in 0.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "through": "^2.3.4",
     "gulp-util": "^2.2.14",
-    "source-map": "^0.1.33"
+    "source-map": "0.1.33"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
Bug causes bad sourcemaps to be generated when there are consecutive
newline characters in files.

See: https://github.com/mozilla/source-map/pull/116

This pin should be removed when source-map 0.1.35 is released.

Fixes issue #13.
