### PR TITLE
trying to fix "source file not found" problem when using with gulp-sourc...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/gulp_test/build

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function(fileName, opts) {
     function endStream(){
         if (!firstFile) return this.emit('end');
 
-        var contentPath = path.join(firstFile.base, fileName),
+        var contentPath = path.join(process.cwd(), fileName),
             mapPath = contentPath + '.map';
         
         if(!firstFile.sourceMap) {
@@ -81,8 +81,6 @@ module.exports = function(fileName, opts) {
         sourceMap.file = path.basename(sourceMap.file);
 
         var contentFile = new File({
-            cwd: firstFile.cwd,
-            base: firstFile.base,
             path: contentPath,
             contents: new Buffer(codeMap.code)
         });
@@ -91,8 +89,6 @@ module.exports = function(fileName, opts) {
             contentFile.sourceMap = sourceMap;
         } else {
             var mapFile = new File({
-                cwd: firstFile.cwd,
-                base: firstFile.base,
                 path: mapPath,
                 contents: new Buffer(JSON.stringify(sourceMap, null, '  '))
             });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "source-map": "0.1.33"
   },
   "devDependencies": {
-    "mocha": "^1.18.2",
-    "chai": "^1.9.0"
+    "chai": "^1.9.0",
+    "coffee-script": "^1.7.1",
+    "gulp": "^3.8.6",
+    "gulp-sourcemaps": "^1.1.0",
+    "mocha": "^1.18.2"
   }
 }

--- a/test/gulp_test/gulpfile.coffee
+++ b/test/gulp_test/gulpfile.coffee
@@ -1,0 +1,13 @@
+gulp = require('gulp')
+sourcemaps = require('gulp-sourcemaps')
+concat = require('../..')
+
+gulp.task 'concat', ->
+	return gulp.src(['./path1/file1.js', './path2/file2.js'])
+		.pipe sourcemaps.init()
+			.pipe concat 'file.js'
+		.pipe sourcemaps.write('.', includeContent: true)
+		.pipe gulp.dest('./build')
+
+gulp.task 'default', ['concat']
+

--- a/test/gulp_test/path1/file1.js
+++ b/test/gulp_test/path1/file1.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/test/gulp_test/path2/file2.js
+++ b/test/gulp_test/path2/file2.js
@@ -1,0 +1,1 @@
+console.log("world");


### PR DESCRIPTION
trying to fix "source file not found" problem when concating files in different path using with gulp-sourcemaps with includeContent: true. I'm not sure this problem is entirely solved, but now it works.
